### PR TITLE
Bug #2

### DIFF
--- a/example/css/index.css
+++ b/example/css/index.css
@@ -7,6 +7,27 @@
   font-family: 'Open-Sans', 'Roboto', Helvetica, Arial, sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Neue', 'Franklin Gothic Medium', 'Arial Narrow', Impact, Haettenschweiler;
 }
 
+.ab {
+  margin: 100px 0;
+  display: block;
+  position: relative;
+  font-size: 4rem;
+  color: orange;
+}
+
+.ab::before {
+  content: 'Abnormal';
+  color: rgba(0,0,0,.4);
+  display: block;
+  transform: rotate3d(-1, 0, 0, 60deg) skew(40deg, 0);
+  perspective: 10px;
+  position: absolute;
+  bottom: -7px;
+  left: -11px;
+  z-index: -1;
+  *filter: blur(1px);
+}
+
 body {
   padding: 0;
   margin: 0;

--- a/example/index.html
+++ b/example/index.html
@@ -16,6 +16,7 @@
         </div>
       </div>
       <div class="main ctx-source">
+        <span class="ab">Abnormal</span>
         <h1>Context Menu</h1>
         <p>
           It is a beautiful moment! <br/>

--- a/example/js/index.js
+++ b/example/js/index.js
@@ -3,10 +3,7 @@
   var ctxSource = document.querySelector('body')
   var target = document.querySelector('.ctx-target')
   var animate = scale(target, 5, 5)
-  var ctxMenu = new ContextMenu(ctxSource, target, {
-    width: window.innerWidth,
-    height: window.innerHeight
-  })
+  var ctxMenu = new ContextMenu(ctxSource, target, window)
   ctxMenu.setup({
     timeout: 800,
     position: 'relative'

--- a/src/position.ts
+++ b/src/position.ts
@@ -31,6 +31,7 @@ export default class Position {
   private get viewBoxBoundingClientRect(): any {
     if (!this.viewBoxIsWindow) {
       // getBoundingClientRect is a expensive function, we shouldn't be calling it always.
+      // @ts-ignore
       this.vBoxClientRect = this.vBoxClientRect === null ? (<HTMLElement> this.viewBox).getBoundingClientRect() : this.vBoxClientRect
       return this.vBoxClientRect
     }

--- a/src/position.ts
+++ b/src/position.ts
@@ -18,6 +18,10 @@ export default class Position {
     this.positioning = 'relative'
   }
 
+  private get viewBoxIsGridLayout(): boolean {
+    return !this.viewBoxIsWindow && (<HTMLElement> this.viewBox).offsetLeft !== this.viewBoxBoundingClientRect.left
+  }
+
   set type(position: Positioning) {
     this.positioning = position
   }

--- a/src/position.ts
+++ b/src/position.ts
@@ -32,7 +32,8 @@ export default class Position {
     return new Path(x, y)
   }
 
-  viewportExcess({ x, y }: Path): ViewPortQuery {
+  viewportExcess(path: Path): ViewPortQuery {
+    const { x, y } = this.transformPath(path)
     const vpq: ViewPortQuery = {
       top: false,
       left: false,
@@ -74,5 +75,15 @@ export default class Position {
 
   private getRelativeY(y: number): number {
     return this.elementBox.height + y > this.box.height ? this.box.height - y : y
+  }
+
+  private transformPath(path: Path): Path {
+    if (this.viewBoxIsGridLayout && this.viewBoxBoundingClientRect !== null) {
+      return new Path(
+        path.x - this.viewBoxBoundingClientRect.left,
+        path.y - this.viewBoxBoundingClientRect.top
+      )
+    }
+    return path
   }
 }

--- a/tests/interact.js
+++ b/tests/interact.js
@@ -10,10 +10,7 @@ describe('Functional Interaction', function() {
     dest.style.height = '200px'
     dest.style.visibility = 'hidden'
     document.body.appendChild(dest)
-    ctxMenu = new ContextMenu(src, dest, {
-      width: window.outerWidth,
-      height: window.outerHeight
-    })
+    ctxMenu = new ContextMenu(src, dest, window)
   })
 
   afterEach(function() {

--- a/tests/positioning.js
+++ b/tests/positioning.js
@@ -11,10 +11,7 @@ describe('Positioning', function() {
     dest.style.height = '200px'
     dest.style.visibility = 'hidden'
     document.body.appendChild(dest)
-    ctxMenu = new ContextMenu(src, dest, {
-      width: window.outerWidth,
-      height: window.outerHeight
-    })
+    ctxMenu = new ContextMenu(src, dest, window)
   })
 
   afterEach(function() {
@@ -52,25 +49,25 @@ describe('Positioning', function() {
   })
 
   it('Relative::should be positioned based on how menu overflows viewport', function(done) {
-    var x = window.outerWidth - dest.offsetWidth / 2
-    var y = window.outerHeight - dest.offsetHeight / 2
+    var x = window.innerWidth - dest.offsetWidth / 2 // if viewport is window, innerWidth is implicitly used in lieu of outerWidth.
+    var y = window.innerHeight - dest.offsetHeight / 2
     var G_viewportQuery = null
     function wrap_assertion() {
       if (G_viewportQuery.right && !G_viewportQuery.bottom) {
-        assert.strictEqual(dest.style.top, y + 'px', 'y positioning is faulty')
-        assert.strictEqual(dest.style.right, dest.offsetWidth / 2 + 'px', 'x positioning is faulty')
+        assert.strictEqual(dest.style.top, y + 'px', 'top-right y positioning is faulty')
+        assert.strictEqual(dest.style.right, dest.offsetWidth / 2 + 'px', 'top-right x positioning is faulty')
       }
       else if (G_viewportQuery.right && G_viewportQuery.bottom) {
-        assert.strictEqual(dest.style.bottom, dest.offsetHeight / 2 + 'px', 'y positioning is faulty')
-        assert.strictEqual(dest.style.right, dest.offsetWidth / 2 + 'px', 'x positioning is faulty')
+        assert.strictEqual(dest.style.bottom, dest.offsetHeight / 2 + 'px', 'bottom-right y positioning is faulty')
+        assert.strictEqual(dest.style.right, dest.offsetWidth / 2 + 'px', 'bottom-right x positioning is faulty')
       }
       else if (!G_viewportQuery.right && G_viewportQuery.bottom) {
-        assert.strictEqual(dest.style.bottom, dest.offsetHeight / 2 + 'px', 'y positioning is faulty')
-        assert.strictEqual(dest.style.left, x + 'px', 'x positioning is faulty')
+        assert.strictEqual(dest.style.bottom, dest.offsetHeight / 2 + 'px', 'bottom-left y positioning is faulty')
+        assert.strictEqual(dest.style.left, x + 'px', 'bottom-left x positioning is faulty')
       }
       else {
-        assert.strictEqual(dest.style.top, y + 'px', 'y positioning is faulty')
-        assert.strictEqual(dest.style.left, x + 'px', 'x positioning is faulty')
+        assert.strictEqual(dest.style.top, y + 'px', 'top-left y positioning is faulty')
+        assert.strictEqual(dest.style.left, x + 'px', 'top-left x positioning is faulty')
       }
     }
     ctxMenu.setup({


### PR DESCRIPTION
It is almost like all grided elements creates another `window` for themselves. I mean if we had a webpage with 3 columns each column has an `offsetLeft` of  `0` *(ZERO)* as though it is not contained in the same window as the remaining columns.
This beahaviour really messes up this positioning system.

This pull request fixes [issue #2](https://github.com/calebpitan/contextmenu/issues/2) 